### PR TITLE
Fix missing entities after EUDA portal format change; remove VIN prefix from entity names

### DIFF
--- a/custom_components/get_euda_data/__init__.py
+++ b/custom_components/get_euda_data/__init__.py
@@ -420,8 +420,8 @@ class PyCupraEntity(Entity):
 
     @property
     def name(self):
-        """Return full name of the entity."""
-        return f"{self.vin} {self._entity_name}"
+        """Return name of the entity."""
+        return self._entity_name
 
     @property
     def should_poll(self) -> bool:

--- a/custom_components/get_euda_data/get_euda_data/eudaconnection.py
+++ b/custom_components/get_euda_data/get_euda_data/eudaconnection.py
@@ -955,7 +955,7 @@ class EUDAConnection:
                     ):
                         vin: str = vehicle.get("vin", "")
                         self.addToAnonymisationDict(vin, "[VIN_ANONYMISED]")
-                        nickName = vehicle.get("nickName", "unknown")
+                        nickName = vehicle.get("nickName", "")
                         newVehicle = {
                             "vin": vin,
                             "brand": self._session_auth_brand,

--- a/custom_components/get_euda_data/get_euda_data/eudavehicle.py
+++ b/custom_components/get_euda_data/get_euda_data/eudavehicle.py
@@ -216,12 +216,8 @@ class EUDAVehicle:
         elif (key.startswith("10000000-0000") or key.startswith("11000000-0000")) and self.tripData != {}:
             return True
         for element in self.currentData.get("Data", []):
-            if (
-                element.get("key", "")
-                == key
-            ):
-                if "value" in element:
-                    return True
+            if element.get("key", "") == key:
+                return True
         return False
 
     @property


### PR DESCRIPTION
## Summary

This PR contains three independent bug fixes discovered while using the integration with a Cupra Leon.

### 1. Fix: Missing entities after EUDA portal format change (`eudavehicle.py`)

`isEUDADataFieldSupported()` previously required both the `key` field **and** a `value` field to be present in each data element:

```python
if element.get("key", "") == key:
    if "value" in element:
        return True
```

The EUDA portal has started omitting the `value` key entirely for fields that have an empty or null value (instead of sending `"value": null` or `"value": ""`). This caused all entities whose current value was empty to report as unsupported, making them disappear from Home Assistant.

**Fix:** Only match on `key` — if the field is present in the data cluster at all, it is supported regardless of whether a `value` key exists alongside it.

### 2. Fix: Device named "unknown" when no nickname is configured (`eudaconnection.py`)

The `nickName` field was defaulting to `"unknown"` when not returned by the API:

```python
nickName = vehicle.get("nickName", "unknown")
```

This caused `vehicle.is_nickname_supported` to return `True` (since `"unknown"` is a non-empty string), so the device in Home Assistant was named "unknown" instead of falling back to the VIN.

**Fix:** Default to `""` so that vehicles without a configured nickname correctly fall back to the VIN as the device name.

### 3. Fix: VIN prefix removed from entity display names (`__init__.py`)

Every entity was previously named `"<VIN> <entity name>"` (e.g. `"VSSZZZKL8SR100398 Fuel level"`). This is redundant because HA already groups entities under a named device, and the VIN prefix makes the entity list hard to read.

**Fix:** Return only the entity-specific name (e.g. `"Fuel level"`), consistent with the standard HA pattern for integrations that expose multiple entities per device.

## Test plan

- [ ] Reload the integration and verify that all previously missing entities (e.g. entities with currently empty values such as range, charge status) reappear
- [ ] Verify the HA device is named with the nickname or VIN, not "unknown"
- [ ] Verify entity display names no longer include the VIN prefix