### PR TITLE
Scale the energy content values by 1/10

### DIFF
--- a/custom_components/get_euda_data/get_euda_data/const.py
+++ b/custom_components/get_euda_data/get_euda_data/const.py
@@ -755,7 +755,7 @@ EUDA_DATA_DICT = {
         "unit": "kWh",
         # "device_class": "temperature",
         "key": "09ed1319-7b17-31c6-ba74-817ce91a4c1d",
-        "conversion": EUDA_DATA_CONVERSION_FLOAT,
+        "conversion": EUDA_DATA_CONVERSION_DIVIDE_BY_10,
     },
     "energy_contents.current_energy_content.physical_value": {
         "attr": "current_energy_content_physical",
@@ -764,7 +764,7 @@ EUDA_DATA_DICT = {
         "unit": "kWh",
         # "device_class": "temperature",
         "key": "84e64812-6eaa-3477-b587-0c5b02d8446f",
-        "conversion": EUDA_DATA_CONVERSION_FLOAT,
+        "conversion": EUDA_DATA_CONVERSION_DIVIDE_BY_10,
     },
     "slope_consumption_values.ascent_slope_consumption.physical_value": {
         "attr": "ascent_slope_consumption_physical",


### PR DESCRIPTION
Both energy content sensors are declared with unit `kWh` but report the raw value, which is in tenths of a kWh.

On an ID.7 Tourer Pro they read:

```
energy_contents.current_energy_content.physical_value = 281.0  → shown as 281.0 kWh
energy_contents.maximal_energy_content.physical_value = 748.0  → shown as 748.0 kWh
```

The car has a battery of roughly 75 kWh, so these are **28.1 kWh** and **74.8 kWh**. As shown, they suggest a 748 kWh battery.

`EUDA_DATA_CONVERSION_DIVIDE_BY_10` already exists and is used for the consumption values, where Volkswagen delivers tenths in the same way — this PR applies it to the two energy content fields as well.

### Why the state of charge still looked right

Anyone deriving a percentage from the pair was unaffected, because the factor cancels out: `281 / 748 = 37.6 %`, and the VW app showed **38 %** at the same moment. That cross-check is what makes the ratio trustworthy as a percentage — but anything reading these two as an absolute energy is off by a factor of ten.

### Evidence

One vehicle (ID.7 Tourer Pro). The V4.0 Data Dictionary documents neither a unit nor a scale for these fields, so the factor rests on the plausibility of the battery size. If someone with a different model can compare the reading against their known capacity, that would settle it for the whole range.